### PR TITLE
Schema updates

### DIFF
--- a/vpts-csv-table-schema.json
+++ b/vpts-csv-table-schema.json
@@ -250,6 +250,7 @@
   ],
   "missingValues": [
     "",
-    "NA"
+    "NA",
+    "NaN"
   ]
 }

--- a/vpts-csv-table-schema.json
+++ b/vpts-csv-table-schema.json
@@ -249,9 +249,12 @@
     },
     {
       "name": "source_file",
-      "description": "Path to the source file from which the data were derived.",
-      "type": "text",
-      "example": "s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06"
+      "description": "URL or path to the source file from which the data were derived.",
+      "type": "string",
+      "example": "s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06",
+      "constraints": {
+        "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$"
+      }
     }
   ],
   "missingValues": [

--- a/vpts-csv-table-schema.json
+++ b/vpts-csv-table-schema.json
@@ -65,7 +65,6 @@
       "type": "number",
       "example": "5.65",
       "constraints": {
-        "required": true,
         "minimum": 0,
         "maximum": 100
       }
@@ -77,7 +76,6 @@
       "type": "number",
       "example": "47.2",
       "constraints": {
-        "required": true,
         "minimum": 0,
         "maximum": 360
       }
@@ -89,7 +87,6 @@
       "type": "number",
       "example": "2.8",
       "constraints": {
-        "required": true,
         "minimum": 0,
         "maximum": 100
       }
@@ -107,7 +104,6 @@
       "example": "46.9",
       "type": "number",
       "constraints": {
-        "required": true,
         "minimum": 0,
         "maximum": "Inf"
       }

--- a/vpts-csv-table-schema.json
+++ b/vpts-csv-table-schema.json
@@ -251,7 +251,7 @@
       "name": "source_file",
       "description": "Path to the source file from which the data were derived.",
       "type": "text",
-      "example": "s3://noaa-nexrad-level2/2019/10/01/KBGM/KBGM20191001_000542_V06"
+      "example": "s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06"
     }
   ],
   "missingValues": [

--- a/vpts-csv-table-schema.json
+++ b/vpts-csv-table-schema.json
@@ -246,6 +246,12 @@
         "minimum": 0.1,
         "maximum": 100
       }
+    },
+    {
+      "name": "source_file",
+      "description": "Path to the source file from which the data were derived.",
+      "type": "text",
+      "example": "s3://noaa-nexrad-level2/2019/10/01/KBGM/KBGM20191001_000542_V06"
     }
   ],
   "missingValues": [

--- a/vpts-csv-table-schema.json
+++ b/vpts-csv-table-schema.json
@@ -208,17 +208,6 @@
       "example": ""
     },
     {
-      "name": "radar_longitude",
-      "description": "Longitude of the radar location in decimal degrees, using the WGS84 datum. Constant for all records from the same `radar`.",
-      "type": "number",
-      "example": "-75.98472",
-      "constraints": {
-        "required": true,
-        "minimum": -180,
-        "maximum": 180
-      }
-    },
-    {
       "name": "radar_latitude",
       "description": "Latitude of the radar location in decimal degrees, using the WGS84 datum. Constant for all records from the same `radar`.",
       "type": "number",
@@ -227,6 +216,17 @@
         "required": true,
         "minimum": -90,
         "maximum": 90
+      }
+    },
+    {
+      "name": "radar_longitude",
+      "description": "Longitude of the radar location in decimal degrees, using the WGS84 datum. Constant for all records from the same `radar`.",
+      "type": "number",
+      "example": "-75.98472",
+      "constraints": {
+        "required": true,
+        "minimum": -180,
+        "maximum": 180
       }
     },
     {


### PR DESCRIPTION
- [x] Fix #39 by making NaN a missing value
- [x] Fix #40 by making a number of columns optional
- [x] Switch order to `lat`, `long`
- [x] Add `source_file` column, #41 

Todo

- [x] Verify with @adokter
- [x] Update https://aloftdata.eu/vpts-csv/#example with new column and data `s3://noaa-nexrad-level2/2016/09/01/KBGM/KBGM20160901_000212_V06`
- [x] Indicate that sort order is `radar`, `datetime`, `height` and `source_file`. The latter will make sure that duplicates are more easy to spot within a height
- [x] Move source file to aloft repo
- [x] Ping @stijnvanhoey about these changes