### PR TITLE
Change definition of direction for v

### DIFF
--- a/vpts-csv-table-schema.json
+++ b/vpts-csv-table-schema.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "v",
-      "description": "Ground speed component north to south in m/s.",
+      "description": "Ground speed component south to north in m/s.",
       "type": "number",
       "example": "3.84",
       "constraints": {


### PR DESCRIPTION
@jshamoun pointed out a discrepancy between how `v` is defined in bioRad and VPTS CSV:

- bioRad [defines](https://adriaandokter.com/bioRad/reference/summary.vp.html) it as "Ground speed component south to north in m/s." So positive values are going north.
- VPTS CSV has it the other way: "Ground speed component north to south in m/s." So positive values are going south.

I think it is likely an error got into the definition in VPTS CSV, but I want to confirm with @bart1 @adokter. Which definition is correct?